### PR TITLE
fix(header): compile in c

### DIFF
--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -121,13 +121,13 @@ typedef MaaAPICallback MaaControllerCallback;
 typedef MaaAPICallback MaaInstanceCallback;
 
 struct MaaCustomControllerAPI;
-typedef MaaCustomControllerAPI* MaaCustomControllerHandle;
+typedef struct MaaCustomControllerAPI* MaaCustomControllerHandle;
 
 struct MaaCustomRecognizerAPI;
-typedef MaaCustomRecognizerAPI* MaaCustomRecognizerHandle;
+typedef struct MaaCustomRecognizerAPI* MaaCustomRecognizerHandle;
 
 struct MaaCustomActionAPI;
-typedef MaaCustomActionAPI* MaaCustomActionHandle;
+typedef struct MaaCustomActionAPI* MaaCustomActionHandle;
 
 struct MaaSyncContextAPI;
-typedef MaaSyncContextAPI* MaaSyncContextHandle;
+typedef struct MaaSyncContextAPI* MaaSyncContextHandle;


### PR DESCRIPTION
`Must use 'struct' tag to refer to type 'MaaCustomControllerAPI'`
修复以引入到c语言环境不能编译的问题